### PR TITLE
Add Google Analytics and Firebase Analytics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Improvements
 
+* **head.html:** added google analytics
 * **assets:** added Carreir favicons (2023-05-29)

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ theme: jekyll-theme-chirpy
 
 # Change the following value to '/PROJECT_NAME' ONLY IF your site type is GitHub Pages Project sites
 # and doesn't have a custom domain.
-baseurl: ''
+baseurl: ""
 
 # The language of the webpage › http://www.lingoes.net/en/translator/langcode.htm
 # If it has the same name as one of the files in folder `_data/locales`, the layout language will also be changed,
@@ -43,7 +43,7 @@ social:
   links:
     # The first element serves as the copyright owner's link
     - https://twitter.com/username      # change to your twitter homepage
-    - https://github.com/username       # change to your github homepage
+    - https://github.com/carrier-io       # change to your github homepage
     # Uncomment below to add more social links
     # - https://www.facebook.com/username
     # - https://www.linkedin.com/in/username
@@ -54,7 +54,7 @@ google_site_verification:               # fill in to your verification string
 # The end of `jekyll-seo-tag` settings
 
 google_analytics:
-  id:                 # fill in your Google Analytics ID
+  id:  G-PVBPGGB71M                # fill in your Google Analytics ID
   # Google Analytics pageviews report settings
   pv:
     proxy_endpoint:   # fill in the Google Analytics superProxy endpoint of Google App Engine

--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ google_site_verification:               # fill in to your verification string
 # The end of `jekyll-seo-tag` settings
 
 google_analytics:
-  id:  G-PVBPGGB71M                # fill in your Google Analytics ID
+  id:  G-Q48K3FS1ZB                # fill in your Google Analytics ID
   # Google Analytics pageviews report settings
   pv:
     proxy_endpoint:   # fill in the Google Analytics superProxy endpoint of Google App Engine

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ timezone: "Eastern Time"
 
 title: Carrier                          # the main title
 
-tagline: Sponsored by EPAM   # it will display as the sub-title
+tagline: Sponsored by EPAM Systems   # it will display as the sub-title
 
 description: >-                        # used by seo meta and the atom feed
     Continuous Test Automation Framework helps to enable shift-left testing practices into Software Development Process without stress of Development Team

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -113,4 +113,37 @@
   {% endunless %}
 
   {% include metadata-hook.html %}
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q48K3FS1ZB"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-Q48K3FS1ZB');
+  </script>
+
+  <script type="module">
+    // Import the functions you need from the SDKs you need
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/9.22.1/firebase-app.js";
+    import { getAnalytics } from "https://www.gstatic.com/firebasejs/9.22.1/firebase-analytics.js";
+    // TODO: Add SDKs for Firebase products that you want to use
+    // https://firebase.google.com/docs/web/setup#available-libraries
+    // Your web app's Firebase configuration
+    // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+    const firebaseConfig = {
+      apiKey: "AIzaSyBPlSbSEEBfzmZtkmPSmO17N_ZSiWvyHN0",
+      authDomain: "getcarrier-516e3.firebaseapp.com",
+      projectId: "getcarrier-516e3",
+      storageBucket: "getcarrier-516e3.appspot.com",
+      messagingSenderId: "28215455168",
+      appId: "1:28215455168:web:ea1cc8ff9da3ca6854ec25",
+      measurementId: "G-2KTG119S71"
+    };
+    // Initialize Firebase
+    const app = initializeApp(firebaseConfig);
+    const analytics = getAnalytics(app);
+  </script>
+
+
 </head>

--- a/_posts/2023-05-30-carrier-install.md
+++ b/_posts/2023-05-30-carrier-install.md
@@ -118,7 +118,7 @@ $ sudo apt install make -y
 $ sudo apt install net-tools -y
 ```
 
-## Ubuntu Steps
+## Ubuntu and Debian Steps
 1. Using root user clone the carrier-io [centry](https://github.com/carrier-io/centry/blob/beta-1.0/Makefile) repository to the `/opt` directory:
 ```bash
 $ cd /opt

--- a/index.html
+++ b/index.html
@@ -554,7 +554,7 @@
       </nav>
       <div class="copyright">
         <p class="copyright__sponsored">Sponsored by EPAM Systems</p>
-        <p class="copyright__text">getcarrier.io &copy; 2022 All rights reserved.</p>
+        <p class="copyright__text">getcarrier.io &copy; 2023 All rights reserved.</p>
       </div>
       <div class="links links__footer">
         <a aria-label="MailUs" class="icon" href="mailto:artem.rozumenko@gmail.com?subject=Question regarding Carrier" rel="noreferrer" target="_blank">


### PR DESCRIPTION
**Description:**

In this pull request, I have made the following updates:

- Added Google Analytics support by updating the theme configuration with the tracking ID.
- Updated `head.html` with both Firebase and Google Analytics tags to enable the tracking of user interactions and traffic data.
- Updated the copyright year in `index.html` to reflect the current year.