### PR TITLE
Extend documentation with project creation and CentOS installation guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .bundle
 vendor
 Gemfile.lock
-
+tmp
 # Jekyll cache
 .jekyll-cache
 _site

--- a/_posts/2023-05-20-carrier-platform-ubuntu.md
+++ b/_posts/2023-05-20-carrier-platform-ubuntu.md
@@ -9,43 +9,82 @@ render_with_liquid: false
 
 ## Installation
 This guide provides step-by-step instructions for installing Carrier on Ubuntu operating systems.
-Carrier is a powerful platform for performance and security testing.
 
-> **INFO** Please find the hardware requirements and prerequisites by following the [link](http://getcarrier.io/posts/carrier-install/#prerequisites).
->>
+> Please find the hardware requirements by following the [link](http://getcarrier.io/posts/carrier-install/#prerequisites).
+{: .prompt-info }
 
-### Steps
+### Prerequisites
+
+Before installing Carrier, you need to ensure that the following tools are installed on your CentOS system:
+
+- [Docker](https://docs.docker.com/desktop/install/ubuntu/) 4.19.0+
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Git](https://git-scm.com/downloads) 2.40.1+
+- [Make](https://wiki.ubuntu.com/ubuntu-make)
+
+> After executing the installation commands, it is important to ensure that there are no errors. Please verify that the installation process completed successfully without encountering any issues.
+{: .prompt-tip }
+
+#### Install Docker
+```bash
+sudo apt update
+sudo apt install docker.io -y
+```
+
+#### Install Docker Compose:
+```bash
+sudo apt install docker-compose -y
+```
+
+#### Install Git Install
+- Check if Git is installed using the following command:
+```bash
+git --version
+```
+- Otherwise, install it:
+```bash
+sudo apt install git -y
+```
+
+#### Install Make:
+```bash
+sudo apt install make -y
+```
+After completing these steps, you have successfully installed Docker, Docker Compose, Git, and Make tools on your Ubuntu system.
+
+### Carrier Installation Steps
 1. Using root user clone the carrier-io [centry](https://github.com/carrier-io/centry/blob/beta-1.0/Makefile) repository to the `/opt` directory:
 ```bash
-$ cd /opt
-$ git clone https://github.com/carrier-io/centry.git -b beta-1.0
+cd /opt
+git clone https://github.com/carrier-io/centry.git -b beta-1.0
 ```
 
 2. Navigate to the downloaded folder:
 ```bash
-$ cd /opt/centry
+cd /opt/centry
 ```
-> You need to use public IP to access Carrier
+    > You need to use public IP to access Carrier
+    {: .prompt-info }
 
 3. Get the `public IP` of your system and set the `CURRENT_IP` variable to the defined value:
 For example, using next cmd:
 ```bash
-$ CURRENT_IP=$(host myip.opendns.com resolver1.opendns.com | grep 'address ' | cut -d ' ' -f 4)
+CURRENT_IP=$(host myip.opendns.com resolver1.opendns.com | grep 'address ' | cut -d ' ' -f 4)
 ```
 
 4. Set parameters in `.env` and `Makefile` file
 
 
-    10.1 Set IP (change `DEV_IP` and `DIRECT_IP` to `CURRENT_IP`):
+    4.1 Set IP (change `DEV_IP` and `DIRECT_IP` to `CURRENT_IP`):
 
-        $ sed -i -e "s/\#DIRECT_IP=FORCE_SET_IP_HERE/DIRECT_IP=$CURRENT_IP/g" Makefile
-        $ sed -i -e "s/\$DEV_IP/$CURRENT_IP/g" .env
+        sed -i -e "s/\#DIRECT_IP=YOUR_IP_HERE/DIRECT_IP=$CURRENT_IP/g" Makefile
+        sed -i -e "s/\$DEV_IP/$CURRENT_IP/g" .env
 
 
 
-    10.2 Set installation path in for `CARRIER_PATH` and `VOLUMES_PATH` in `.env`:
+    4.2 Set installation path in for `CARRIER_PATH` and `VOLUMES_PATH` in `.env`:
 
-        $ vi .env
+        vi .env
         ....
         CARRIER_PATH=/opt/centry
         VOLUMES_PATH=/opt/centry/volumes
@@ -53,14 +92,13 @@ $ CURRENT_IP=$(host myip.opendns.com resolver1.opendns.com | grep 'address ' | c
 
 5. Review list of default plugins in config file:
 ```bash
-$ cat config/pylon.yml
+cat config/pylon.yml
 ```
 
 6. Launch the Carrier installer:
 ```bash
-$ make up
+make up
 ```
-> Please note that installation of the Carrier installer takes from 5 to 10 minutes.
 
     Expected Output:
 
@@ -102,10 +140,10 @@ $ make up
     ```
     Verify that main container is started:
     > Packages downloading process takes ~5-10 minutes
-
+    {: .prompt-info }
 
     ```bash
-    $ docker logs -f carrier-pylon
+    docker logs -f carrier-pylon
     ```
 
     Expected Output:
@@ -127,7 +165,7 @@ $ make up
     Verify that no Docker containers have been restarted:
 
     ```bash
-    $ docker ps -a
+    docker ps -a
     ```
 
 7. Once the installation is finished, open the following URL in a browser: `http://<public DNS or IP>`
@@ -137,3 +175,42 @@ $ make up
     ![Carrier login form](/assets/posts_img/login_screen.png)
 
     > You're all set, then! Excellent Work!
+    {: .prompt-info }
+
+## Next Step: Create a Project in Carrier
+
+Once you have completed the installation steps, you can proceed to create your first project in Carrier.
+The project allows you to organize and manage your performance and security tests.
+
+Follow the guide on [how to create a project in Carrier](http://getcarrier.io/posts/carrier-create-project/) to get started.
+
+## Troubleshooting
+
+1. Restart carrier-pylon container
+
+```bash
+docker restart carrier-pylon
+docker logs -f carrier-pylon
+```
+
+If something doesn't work as expected, check the logs of the following containers for any errors:
+
+```bash
+docker logs -f carrier-keycloak
+docker logs -f centry_traefik_1
+docker logs -f carrier-pylon-auth
+```
+
+## Uninstall
+If the root volume was used as the hard drive, use the following commands to stop containers and remove all required artifacts:
+```bash
+docker-compose down
+docker volume prune
+docker network prune
+```
+
+If a mounted disk was used, manually delete all directories with images:
+```bash
+docker-compose down
+sudo rm -rf /opt/docker
+```

--- a/_posts/2023-05-30-carrier-install.md
+++ b/_posts/2023-05-30-carrier-install.md
@@ -1,19 +1,20 @@
 ---
-title:  Carrier Installation
+title: Carrier Installation Guide
 author: User
 date: 2023-05-30 12:00:00 +0800
 categories: [Performance, Tutorial]
 tags: [performance, installation, ubuntu, centos]
 render_with_liquid: false
+pin: true
 ---
- 
-## Installation
-This guide provides step-by-step instructions for installing Carrier on Ubuntu operating systems. 
-Carrier is a powerful platform for performance and security testing. 
 
-> **INFO** This installation guide is for HTTP-only configurations.
->
+## Overview
+Carrier is a powerful platform for performance and security testing.
+This guide includes a table with hardware requirements, cloud provider recommendations, and software installation steps.
+It also contains links to the specific installation guides for Ubuntu and Centos platforms.
+
 > Please be aware that the instructions provided in this guide are specifically designed for setting up a Carrier platform using HTTP protocol. Configuring the platform for HTTPS require additional steps not covered here.
+{: .prompt-info }
 
 ### Prerequisites
 
@@ -27,6 +28,10 @@ To install Carrier successfully, your Linux host must meet the following hardwar
 | IP address or DNS              | Static              |
 | Inbound ports                  | http – 80, ssh - 22, tcp - 3100, http - 5672(rabbitmq), http - 8086 (influxdb)|
 
+> Mounted drive is better option as it gives possibility to move carrier data to other instance or not lose data in case if instance is terminated accidentally.
+> Please find how to mount disk steps by the link: [how](#how-to-mount-disks)
+{: .prompt-tip }
+
 As a load generator it is recommended to use separate virtual machine:
 
 | Load generator hardware minimal requirements  |                    |
@@ -34,8 +39,6 @@ As a load generator it is recommended to use separate virtual machine:
 | CPU                            | 2 (and more)       |
 | RAM                            | 8 GB (and more)    |
 
-
-> Please note that the specifications mentioned above are recommendations and can be adjusted based on your specific requirements and workload. Make sure to choose the appropriate instance types or virtual machine sizes that align with the Carrier instance requirements.
 
 ### Cloud Provider Recommendations
 
@@ -55,8 +58,12 @@ For Carrier installation on Azure, you can use virtual machines that meet the fo
 - OS Disk: 100-500GB Premium SSD
 - IP: Assign a static IP to the virtual machine
 
-> For Azure it is reccomended to disable daily updates to avoid Docker restarts:
 
+> To prevent Docker restarts on Azure, it is recommended to disable daily updates.
+{: .prompt-tip }
+
+
+Follow the steps below to disable the daily updates:
 1. Check if you have any daily services enabled using the following command:
 ```bash
 $ sudo systemctl list-timers
@@ -85,233 +92,32 @@ For Carrier installation on GCP, you can use Compute Engine instances that meet 
 - Boot Disk: 100-500GB SSD
 - IP: Assign a static IP to the instance
 
-#### Software
+> Please note that the specifications mentioned above are recommendations and can be adjusted based on your specific requirements and workload. Make sure to choose the appropriate instance types or virtual machine sizes that align with the Carrier instance requirements.
+{: .prompt-info }
 
-1. Install [Docker](https://docs.docker.com/desktop/install/ubuntu/) 4.19.0+:
-```bash
-$ sudo apt update
-$ sudo apt install docker.io -y
-```
+## Install on Ubuntu
 
-2. Install Docker [Compose](https://docs.docker.com/compose/install/):
-```bash
-$ sudo apt install docker-compose -y
-```
-> Make sure you're got no errors after the build step command.
+For detailed instructions on installing Carrier on Ubuntu, refer to the [Ubuntu Installation Steps](/carrier-io.github.io/posts/carrier-platform-ubuntu/).
 
-5. If the hardware drive is not the root drive, mount the disk to the /opt directory.
-> Please find how to mount disk steps by the link: [how](#how-to-mount-disks)
+## Install on CentOS
 
-6. Install [Git](https://git-scm.com/downloads) 2.40.1+ :
-- Check if Git is installed using the following command:
-```bash
-$ git --version
-```
-- Otherwise, install it:
-```bash
-$ sudo apt install git -y
-```
+For detailed instructions on installing Carrier on CentOS, refer to the [CentOS Installation Steps](/carrier-io.github.io/posts/carrier-platform-centos/).
 
-7. Install Make and net-tools:
-```bash
-$ sudo apt install make -y
-$ sudo apt install net-tools -y
-```
-
-## Ubuntu and Debian Steps
-1. Using root user clone the carrier-io [centry](https://github.com/carrier-io/centry/blob/beta-1.0/Makefile) repository to the `/opt` directory:
-```bash
-$ cd /opt
-$ git clone https://github.com/carrier-io/centry.git -b beta-1.0
-```
-
-2. Navigate to the downloaded folder:
-```bash
-$ cd /opt/centry
-```
-> You need to use public IP to access Carrier
-
-3. Get the `public IP` of your system and set the `CURRENT_IP` variable to the defined value:
-For example, using next cmd:
-```bash
-$ CURRENT_IP=$(host myip.opendns.com resolver1.opendns.com | grep 'address ' | cut -d ' ' -f 4)
-```
-
-4. Set parameters in `.env` and `Makefile` file
-
-    
-    10.1 Set IP (change `DEV_IP` and `DIRECT_IP` to `CURRENT_IP`):
-        
-        $ sed -i -e "s/\#DIRECT_IP=FORCE_SET_IP_HERE/DIRECT_IP=$CURRENT_IP/g" Makefile
-        $ sed -i -e "s/\$DEV_IP/$CURRENT_IP/g" .env
-        
-
-
-    10.2 Set installation path in for `CARRIER_PATH` and `VOLUMES_PATH` in `.env`:
-        
-        $ vi .env 
-        ....    
-        CARRIER_PATH=/opt/centry
-        VOLUMES_PATH=/opt/centry/volumes
-        ....
-
-5. Review list of default plugins in config file:
-```bash
-$ cat config/pylon.yml
-```
-
-6. Launch the Carrier installer:
-```bash
-$ make up
-```
-> Please note that installation of the Carrier installer takes from 5 to 10 minutes.
-
-    Expected Output after finishing download process:
-
-    ```console
-    Status: Downloaded newer image for grafana/grafana:latest
-    Pulling pylon (getcarrier/pylon:latest)...
-    latest: Pulling from getcarrier/pylon
-    918547b94326: Pull complete
-    5d79063a01c5: Pull complete
-    4eedd9c5abf7: Pull complete
-    9cdadd40055f: Pull complete
-    2a12d0031f3f: Pull complete
-    2d4866cf6449: Pull complete
-    406c88e1abe3: Pull complete
-    02df300aa56e: Pull complete
-    167443f87bae: Pull complete
-    2cd12cb7de27: Pull complete
-    b18d02dee478: Pull complete
-    2c59c872b36d: Pull complete
-    cb98fd0463c7: Pull complete
-    Digest: sha256:c9704508366b319d0c2c0414fb7271e34b458fb63a794522bf03833b9ba509ae
-    Status: Downloaded newer image for getcarrier/pylon:latest
-    Creating carrier-influx   ... done
-    Creating carrier-postgres ... done
-    Creating carrier-redis    ... done
-    Creating carrier-loki     ... done
-    Creating carrier-mongo    ... done
-    Creating carrier-minio    ... done
-    Creating carrier-grafana  ... done
-    Creating carrier-vault    ... done
-    Creating centry_traefik_1 ... done
-    Creating carrier-rabbit   ... done
-    Creating carrier-keycloak             ... done
-    Creating carrier-interceptor          ... done
-    Creating carrier-interceptor_internal ... done
-    Creating carrier-pylon-worker         ... done
-    Creating carrier-pylon-auth           ... done
-    Creating carrier-pylon                ... done
-    ```
-    Verify that main container is started: 
-    > Packages downloading process takes ~5-10 minutes
-
-
-    ```bash
-    $ docker logs -f carrier-pylon
-    ```
-
-    Expected Output after finishing download process:
-
-    ```console
-    INFO - pylon.core.tools.process - Stored in directory: /root/.cache/pip/wheels/e3/76/6f/c25be6a9e6cc9985b96e8c95997d46790242c6426ef68e754c
-    INFO - pylon.core.tools.process - Successfully built jsonpath_rw
-    INFO - pylon.core.tools.process - Installing collected packages: ply, decorator, jsonpath_rw
-    INFO - pylon.core.tools.process - Successfully installed decorator-5.1.1 jsonpath_rw-1.4.0 ply-3.11
-    INFO - plugins.auth_mappers.module - Initializing module
-    INFO - plugins.auth_oidc.module - Initializing module
-    INFO - plugins.auth_root.module - Initializing module auth_root
-    INFO - pylon.core.tools.server - Starting Flask server
-    * Tip: There are .env or .flaskenv files present. Do "pip install python-dotenv" to use them.
-    WARNING - werkzeug -  * Debugger is active!
-    INFO - werkzeug -  * Debugger PIN: 686-802-926
-    ```
-
-    Verify that no Docker containers have been restarted: 
-
-    ```bash
-    $ docker ps -a 
-    ```
-
-7. Once the installation is finished, open the following URL in a browser: `http://<public DNS or IP>`
-
-8. Login for the first time to the system using the `admin/admin` credentials.
-
-    ![Carrier login form](/assets/posts_img/login_screen.png)
-
-    > You're all set, then! Excellent Work! 
-
-
-## How to create a project in Carrier
-
-1. Once you log in, you will see a page indicating that there are no projects created yet.
-    ![Carrier after login](/assets/posts_img/main_page.png)
-
-2. Click on the person logo in the top right corner and select "Administration" to switch to Administration mode and create your first project.
-
-    ![Carrier select admin](/assets/posts_img/select_admin.png)
-
-3. Click on the plus sign to add the project. Set the name of your project and click "Create".
-
-    3.1 Open ![Carrier plus btn](/assets/posts_img/plus_project.png)
-
-
-    3.2 Save ![Carrier set name ](/assets/posts_img/set_name_prj_new.png)
-
-4. Your project will be created. It might take around 1 minute. You can track the process of project creation in the carrier-pylon logs to ensure that there are no errors.
-
-    ```bash
-$ docker logs -f carrier-pylon 
-``` 
-
-5. Once the project is created, you can switch back to Project mode.
-
-    ![Carrier plus btn](/assets/posts_img/project_mode.png)
-
-    You will get to Project configuration page.
-
-    ![Carrier demo ](/assets/posts_img/demo_prj.png)
-
-6. You can navigate to the required sections, either Performance or Security, to start configuring tests using the left menu in the dropdown list.
-
-    ![Carrier menu ](/assets/posts_img/dropdown.png)
-
-    Performance:
-
-    ![Carrier perf ](/assets/posts_img/perf_screen.png)
-
-## Troubleshooting
-
-1. Restart main container 
-
-```bash
-$ docker restart carrier-pylon
-$ docker logs -f carrier-pylon
-```
-
-If something doesn't work as expected, check the logs of the following containers for any errors:
-
-```bash
-$ docker logs -f carrier-keycloak
-$ docker logs -f centry_traefik_1
-$ docker logs -f carrier-pylon-auth
-```
 
 ### How to mount disks
 1. Get the list of all available partitions on your system with the following command:
     ```bash
-$ sudo fdisk -l
+sudo fdisk -l
 ```
 
 2. Make a new file system:
     ```bash
-$ sudo mkfs -t ext4 /dev/nvme1n1
+sudo mkfs -t ext4 /dev/nvme1n1
 ```
 
 3. Add information about the new filesystem in the file system table by editing /etc/fstab:
     ```bash
-$ sudo vi /etc/fstab
+sudo vi /etc/fstab
 ```
 
 4. Add the following line at the end of the file:
@@ -321,28 +127,14 @@ $ sudo vi /etc/fstab
 
 5. Mount the required file system to the existing /opt directory:
     ```bash
-$ sudo mount /dev/nvme1n1 /opt
+sudo mount /dev/nvme1n1 /opt
 ```
 
 6. Mount Docker to the /opt folder:
     ```bash
-$ cd /opt
-$ sudo mkdir docker
-$ sudo service docker stop
-$ sudo mount --rbind /opt/docker /var/lib/docker
-$ sudo service docker start
-```
-
-## Uninstall
-If the root volume was used as the hard drive, use the following commands to stop containers and remove all required artifacts:
-```bash
-$ docker-compose down
-$ docker volume prune
-$ docker network prune
-```
-
-If a mounted disk was used, manually delete all directories with images:
-```bash
-$ docker-compose down
-$ sudo rm -rf /opt/docker
+cd /opt
+sudo mkdir docker
+sudo service docker stop
+sudo mount --rbind /opt/docker /var/lib/docker
+sudo service docker start
 ```

--- a/_posts/2023-05-30-carrier-platform-centos.md
+++ b/_posts/2023-05-30-carrier-platform-centos.md
@@ -1,0 +1,305 @@
+---
+title: Centos Installation Steps
+author: User
+date: 2023-05-20 12:00:00 +0800
+categories: [Performance, Tutorial]
+tags: [performance, installation, centos]
+render_with_liquid: false
+---
+
+## Centos Installation Steps
+
+This guide provides step-by-step instructions for installing Carrier on CentOS operating systems. Carrier is a powerful platform for performance and security testing.
+
+> Please find the hardware requirements by following the [link](http://getcarrier.io/posts/carrier-install/#prerequisites).
+{: .prompt-info }
+
+### Prerequisites
+
+Before installing Carrier, you need to ensure that the following tools are installed on your CentOS system:
+
+- Docker
+- Docker Compose
+- Git
+- Make
+
+> After executing the installation commands, it is important to ensure that there are no errors. Please verify that the installation process completed successfully without encountering any issues.
+{: .prompt-tip }
+
+#### Install Docker
+
+1. Update the system:
+```bash
+sudo yum update -y
+```
+
+    Expected Output:
+
+    ```
+      python3-attrs-20.3.0-7.el9.noarch
+      python3-jsonschema-3.2.0-13.el9.noarch
+      python3-pyrsistent-0.17.3-8.el9.x86_64
+
+    Complete!
+    ```
+
+2. Install required packages:
+```bash
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+```
+
+3. Set up the Docker repository:
+```bash
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+```
+
+4. Install Docker:
+```bash
+sudo yum install docker-ce
+```
+
+5. Start and enable Docker service:
+```bash
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+6. Verify that Docker is installed correctly:
+```bash
+docker --version
+```
+
+    Expected Output:
+
+    ```
+    [root@ip-172-31-26-250 ec2-user]# docker --version
+    Docker version 24.0.2, build cb74df
+    ```
+
+#### Install Docker Compose
+
+1. Ensure that you have Docker installed on your CentOS system. If Docker is not installed, you can refer to the previous instructions to install it.
+
+2. Download the Docker Compose binary into the `/usr/local/bin` directory:
+```bash
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+```
+
+3. Apply executable permissions to the Docker Compose binary:
+```bash
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+4. Create a symbolic link for docker-compose in `/usr/bin/docker-compose`:
+```bash
+sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+```
+
+5. Verify that Docker Compose is installed correctly:
+```bash
+docker-compose --version
+```
+
+    Expected Output:
+
+    ```
+    [root@ip-172-31-26-250 ec2-user]# docker-compose --version
+    Docker Compose version v2.18.1
+    ```
+
+#### Install Git
+
+1. Install Git:
+```bash
+sudo yum install git -y
+```
+
+2. Verify the Git installation:
+```bash
+git --version
+```
+  Expected Output:
+
+    ```
+    [root@ip-172-31-26-250 ec2-user]# git version
+    git version 2.39.1
+    ```
+
+#### Install Make
+
+1. Install the Development Tools group package:
+```bash
+sudo yum groupinstall "Development Tools" -y
+```
+
+2. Verify the Make installation:
+```bash
+make --version
+```
+
+After completing these steps, you have successfully installed Docker, Docker Compose, Git, and Make tools on your CentOS system.
+
+Make sure to execute these additional steps before proceeding with the Carrier installation to ensure that all the required tools are installed on your CentOS system.
+### Carrier Installation Steps
+> You need to use public IP to access Carrier
+{: .prompt-info }
+
+1. Using root user clone the carrier-io centry repository to the `/opt` directory:
+```bash
+cd /opt
+git clone https://github.com/carrier-io/centry.git -b beta-1.0
+```
+
+2. Navigate to the downloaded folder:
+```bash
+cd /opt/centry
+```
+3. Get the `public IP` of your system and set the `CURRENT_IP` variable to the defined value:
+For example, using next cmd:
+```bash
+CURRENT_IP=$(host myip.opendns.com resolver1.opendns.com | grep 'address ' | cut -d ' ' -f 4)
+```
+
+4. Set parameters in `.env` and `Makefile` file
+
+    4.1 Set IP (change `DEV_IP` and `DIRECT_IP` to `CURRENT_IP`):
+
+        sed -i -e "s/\#DIRECT_IP=YOUR_IP_HERE/DIRECT_IP=$CURRENT_IP/g" Makefile
+        sed -i -e "s/\$DEV_IP/$CURRENT_IP/g" .env
+
+    4.2 Set installation path in for `CARRIER_PATH` and `VOLUMES_PATH` in `.env`:
+
+        vi .env
+        ....
+        CARRIER_PATH=/opt/centry
+        VOLUMES_PATH=/opt/centry/volumes
+        ....
+
+5. Review list of default plugins in config file and update rabbitmq container version:
+```bash
+sed -i -e "s/\image: rabbitmq:3.7-management/image: rabbitmq:3.9-management/g" docker-compose.yaml
+cat config/pylon.yml
+```
+
+6. Launch the Carrier installer:
+```bash
+make up
+```
+
+    Expected Output:
+
+    ```
+     [+] Running 126/26
+     ✔ vault 5 layers [⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                        15.4s
+     ✔ loki 7 layers [⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                        6.0s
+     ✔ minio 6 layers [⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                       22.9s
+     ✔ mongo 9 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                    36.2s
+     ✔ postgres 13 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                            32.0s
+     ✔ pylon 11 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                 45.8s
+     ✔ pylon_auth Pulled                                                                                                    45.8s
+     ✔ grafana 9 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                  28.0s
+     ✔ redis 6 layers [⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                       15.6s
+     ✔ traefik 4 layers [⣿⣿⣿⣿]      0B/0B      Pulled                                                                        9.7s
+     ✔ rabbitmq 12 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                             25.4s
+     ✔ keycloak 4 layers [⣿⣿⣿⣿]      0B/0B      Pulled                                                                      39.6s
+     ✔ influx 7 layers [⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                     33.2s
+     ✔ interceptor 18 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                    42.8s
+     ✔ interceptor_internal Pulled                                                                                          42.7s
+    ....
+    [+] Building 0.0s (0/0)
+    [+] Running 16/16
+     ✔ Network centry_pylon                    Created                                                                       0.1s
+     ✔ Container carrier-redis                 Started                                                                      17.3s
+     ✔ Container carrier-mongo                 Started                                                                      17.4s
+     ✔ Container carrier-loki                  Started                                                                      17.7s
+     ✔ Container carrier-minio                 Started                                                                      17.4s
+     ✔ Container carrier-postgres              Started                                                                      17.5s
+     ✔ Container carrier-influx                Started                                                                      17.5s
+     ✔ Container carrier-vault                 Started                                                                       2.1s
+     ✔ Container centry-traefik-1              Started                                                                       1.5s
+     ✔ Container carrier-rabbit                Started                                                                       2.0s
+     ✔ Container carrier-grafana               Started                                                                       2.0s
+     ✔ Container carrier-keycloak              Started                                                                       2.3s
+     ✔ Container carrier-interceptor_internal  Started                                                                       3.0s
+     ✔ Container carrier-interceptor           Started                                                                       2.8s
+     ✔ Container carrier-pylon-auth            Started                                                                       3.3s
+     ✔ Container carrier-pylon                 Started
+    ```
+
+    Verify that main container is started:
+    > Packages downloading process takes ~5-10 minutes
+    {: .prompt-info }
+
+    ```bash
+    docker logs -f carrier-pylon
+    ```
+
+    Expected Output:
+
+    ```
+    INFO - pylon.core.tools.process - Stored in directory: /root/.cache/pip/wheels/e3/76/6f/..
+    INFO - pylon.core.tools.process - Successfully built jsonpath_rw
+    INFO - pylon.core.tools.process - Installing collected packages: ply, decorator, jsonpath_rw
+    INFO - pylon.core.tools.process - Successfully installed decorator-5.1.1 jsonpath_rw-1.4.0 ply-3.11
+    INFO - plugins.auth_mappers.module - Initializing module
+    INFO - plugins.auth_oidc.module - Initializing module
+    INFO - plugins.auth_root.module - Initializing module auth_root
+    INFO - pylon.core.tools.server - Starting Flask server
+    * Tip: There are .env or .flaskenv files present. Do "pip install python-dotenv" to use them.
+    WARNING - werkzeug -  * Debugger is active!
+    INFO - werkzeug -  * Debugger PIN: 686-802-926
+    ```
+
+    Verify that no Docker containers have been restarted:
+
+    ```bash
+    docker ps -a
+    ```
+
+7. Once the installation is finished, open the following URL in a browser: `http://<public DNS or IP>`
+
+8. Login for the first time to the system using the `admin/admin` credentials.
+
+    ![Carrier login form](/assets/posts_img/login_screen.png)
+
+    > You're all set, then! Excellent Work!
+    {: .prompt-info }
+
+## Next Step: Create a Project in Carrier
+
+Once you have completed the installation steps, you can proceed to create your first project in Carrier.
+The project allows you to organize and manage your performance and security tests.
+
+Follow the guide on [how to create a project in Carrier](http://getcarrier.io/posts/carrier-create-project/) to get started.
+
+
+## Troubleshooting
+
+1. Restart carrier-pylon container
+
+```bash
+docker restart carrier-pylon
+docker logs -f carrier-pylon
+```
+
+If something doesn't work as expected, check the logs of the following containers for any errors:
+
+```bash
+docker logs -f carrier-keycloak
+docker logs -f centry_traefik_1
+docker logs -f carrier-pylon-auth
+```
+
+## Uninstall
+If the root volume was used as the hard drive, use the following commands to stop containers and remove all required artifacts:
+```bash
+docker-compose down
+docker volume prune
+docker network prune
+```
+
+If a mounted disk was used, manually delete all directories with images:
+```bash
+docker-compose down
+sudo rm -rf /opt/docker
+```

--- a/_posts/2023-05-31-carrier-create-project.md
+++ b/_posts/2023-05-31-carrier-create-project.md
@@ -1,0 +1,56 @@
+---
+title: Create a Project in Carrier
+author: User
+date: 2023-05-30 12:00:00 +0800
+categories: [Performance, Tutorial]
+tags: [performance, project, configuration]
+render_with_liquid: false
+---
+
+## Overview
+
+This guide provides step-by-step instructions on how to create a project in Carrier.
+It includes screenshots to help you navigate through the process and highlights key steps to follow.
+
+## How to Create a Project in Carrier
+
+1. Once you log in to Carrier, you will see a page indicating that there are no projects created yet.
+
+    ![Carrier after login](/assets/posts_img/main_page.png)
+
+2. Click on the person logo in the top right corner and select "Administration" to switch to Administration mode and create your first project.
+
+    ![Carrier select admin](/assets/posts_img/select_admin.png)
+
+3. Click on the plus sign to add the project. Set the name of your project and click "Create".
+
+    ![Carrier plus btn](/assets/posts_img/plus_project.png)
+
+    Set the name for your project in the dialog box and click "Create".
+
+    ![Carrier set name](/assets/posts_img/set_name_prj_new.png)
+
+4. Your project will be created. It might take around 1 minute. You can track the process of project creation in the carrier-pylon logs to ensure that there are no errors. Open a terminal and run the following command:
+
+    ```bash
+    $ docker logs -f carrier-pylon
+    ```
+
+5. Once the project is created, you can switch back to Project mode.
+
+    ![Carrier project mode](/assets/posts_img/project_mode.png)
+
+    You will be redirected to the Project configuration page.
+
+    ![Carrier demo](/assets/posts_img/demo_prj.png)
+
+6. To start configuring tests, navigate to the required sections, either Performance or Security, using the left menu dropdown list.
+
+    ![Carrier menu](/assets/posts_img/dropdown.png)
+
+    In the Performance section, you can configure performance tests.
+
+    ![Carrier performance](/assets/posts_img/perf_screen.png)
+
+---
+


### PR DESCRIPTION
**Description:**

In this pull request, I have made the following updates to the documentation:

- Added a guide on `How to create a project`, which covers the steps to set up a new project, configure dependencies, and initialize the working environment.
- Added a guide on `How to install on CentOS`, which provides step-by-step instructions for installing the required software and tools on a CentOS system, along with any necessary configuration steps.